### PR TITLE
[Feat] 웹폰트 최적화 with 라이브러리 설치 (#6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" href="./src/assets/taco.svg" type="image/x-icon" />
-    <link
-      rel="preload"
-      href="./src/fonts/EsamanruMedium-subset.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
 
     <title>today-matZip</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "today-menu",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/gothic-a1": "^5.2.8",
+        "@fontsource/single-day": "^5.2.8",
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -923,6 +925,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/gothic-a1": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/gothic-a1/-/gothic-a1-5.2.8.tgz",
+      "integrity": "sha512-TGkEbNiU3BVy6KtEPHvwAl77eMRkElCVwO2V+1lvjBcvVwRvI47sGRW1+9Ylg2jS1Bocl6kNcDXUHKrntgHnZQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/single-day": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/single-day/-/single-day-5.2.8.tgz",
+      "integrity": "sha512-7MXQXiM+b6Zf0juhBdGqfmS5sc1jPprvK5DI0T60IsU/JenIXYo7VgMF1Dbm+YwPiwdgMibAksFwYsHMifEA8Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/gothic-a1": "^5.2.8",
+    "@fontsource/single-day": "^5.2.8",
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -3,3 +3,8 @@ declare module '*.svg' {
   const src: string;
   export default src;
 }
+
+// d.ts
+declare module '*.css';
+declare module '@fontsource/*' {}
+declare module '@fontsource-variable/*' {}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,8 +18,8 @@ export default function Card({ data }: CardProps) {
                 src={`${BASE_URL}/${place.image.src}`}
                 className="aspect-square w-full rounded-lg bg-gray-200 object-cover group-hover:opacity-50 xl:aspect-7/8"
               />
-              <h3 className="mt-4 text-sm text-gray-700 font-Esamanru-Light">{place.title}</h3>
-              <p className="mt-1 text-lg font-Esamanru-Light text-gray-900">{place.description}</p>
+              <h3 className="mt-4 text-sm text-gray-700 ">{place.title}</h3>
+              <p className="mt-1 text-lg  text-gray-900">{place.description}</p>
             </a>
           ))}
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ export default function Header() {
   return (
     <header className="flex flex-col justify-center gap-3 items-center">
       <Taco></Taco>
-      <h1 className="text-5xl font-bold">맛집 뿌셔뿌셔</h1>
+      <h1 className="text-5xl font-bold mb-8">맛집 뿌셔뿌셔</h1>
     </header>
   );
 }

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -28,13 +28,13 @@ export default function List({ title, type }: ListProps) {
   }
   return (
     <section className="my-3 border-4 rounded-2xl border-orange-400 items-center gap-3 flex flex-col p-3 justify-center ">
-      <h2 className="text-3xl font-Esamanru-Bold">{title}</h2>
+      <h2 className="text-3xl font-semibold py-4">{title}</h2>
 
       {/* data 찜한 맛집과 전체맛집 컴포넌트 분리 */}
       {data ? (
         <Card data={data}></Card>
       ) : (
-        <div className="p-10 text-center text-gray-500 text-xl font-Esamanru-Light">
+        <div className="p-10 text-center text-gray-500 text-2xl font-medium">
           찜한 맛집이 아직 없어요 😢
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,39 +1,159 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* gothic-a1-korean-100-normal */
 @font-face {
-  font-family: 'Esamanru-Bold';
-  src: url('./fonts/EsamanruBold-subset.woff') format('woff');
-  src: url('./fonts/EsamanruBold-subset.woff2') format('woff2');
+  font-family: 'Gothic A1';
+  font-style: normal;
   font-display: swap;
-  /* swap 폰트 로드 되기 전까지 기본폰트로 먼저 표시 */
+  font-weight: 100;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-100-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-100-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-100-normal.ttf)
+      format('truetype');
 }
+
+/* gothic-a1-korean-200-normal */
 @font-face {
-  font-family: 'Esamanru-Light';
-  src: url('./fonts/EsamanruLight-subset.woff') format('woff');
-  src: url('./fonts/EsamanruLight-subset.woff2') format('woff2');
+  font-family: 'Gothic A1';
+  font-style: normal;
   font-display: swap;
-  /* swap 폰트 로드 되기 전까지 기본폰트로 먼저 표시 */
+  font-weight: 200;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-200-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-200-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-200-normal.ttf)
+      format('truetype');
 }
+
+/* gothic-a1-korean-300-normal */
 @font-face {
-  font-family: 'Esamanru-Medium';
-  src: url('./fonts/EsamanruMedium-subset.woff') format('woff');
-  src: url('./fonts/EsamanruMedium-subset.woff2') format('woff2');
+  font-family: 'Gothic A1';
+  font-style: normal;
   font-display: swap;
-  /* swap 폰트 로드 되기 전까지 기본폰트로 먼저 표시 */
+  font-weight: 300;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-300-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-300-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-300-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-400-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-400-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-400-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-400-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-500-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-500-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-500-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-500-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-600-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-600-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-600-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-600-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-700-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-700-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-700-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-700-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-800-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 800;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-800-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-800-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-800-normal.ttf)
+      format('truetype');
+}
+
+/* gothic-a1-korean-900-normal */
+@font-face {
+  font-family: 'Gothic A1';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 900;
+  src:
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.woff2)
+      format('woff2'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.woff)
+      format('woff'),
+    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.ttf)
+      format('truetype');
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Gothic A1', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -183,24 +303,4 @@ button:focus-visible {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-    font-family: var(--font-Esamanru-Medium);
-    line-height: 1.5;
-    font-weight: 500;
-    letter-spacing: 0.15px; /* 폴백 대비 조정 */
-    word-spacing: -1.4px;
-  }
-}
-
-@theme {
-  --font-Esamanru-Bold: Esamanru-Bold, 'Helvetica Neue', Arial, sans-serif;
-  --font-Esamanru-Light: Esamanru-Light, 'Helvetica Neue', Arial, sans-serif;
-  --font-Esamanru-Medium: Esamanru-Medium, 'Helvetica Neue', Arial, sans-serif;
 }


### PR DESCRIPTION
<!-- PR 제목 예시:
ex) [PR] 기능 구현 (#이슈번호)
-->

## #️⃣ 연관된 이슈

- #6 

## 📑 구현 사항

- 라이브러리 설치하여 폰트 다운로드 없이 웹폰트 사용

## 🌀 어려웠던 점
- 워낙 라이브러리 소개가 잘 되어 있어서 적용시키는데에 어려움은 없었다! 
- 이전에 웹최적화에 사용되었던 , 직접 폰트 불러오는 작업의 장단점을 비교하여 개발일지에 정리해보았다.
- [개발일지](https://velog.io/@jovm268/React-Vite-Typescript-%EC%9B%B9%ED%8F%B0%ED%8A%B8-%EC%B5%9C%EC%A0%81%ED%99%94-subset-%ED%8C%8C%EC%9D%BC-woff2-%EB%B3%80%ED%99%98-%EC%84%9C%EB%B8%8C%EC%85%8B%EB%A6%AC%EC%8A%A4%ED%8A%B8)

## 📸 구현 이미지
<img width="1632" height="1521" alt="스크린샷 2025-10-22 오후 9 42 24" src="https://github.com/user-attachments/assets/f61182f9-b9c8-470b-88c2-53dd94683a3d" />


## ❇️ 코드 설명
### 타입스크립트 정의
```tsx
declare module '*.css';
declare module '@fontsource/*' {}
declare module '@fontsource-variable/*' {}
```

### 폰트 불러오기 
```tsx
@font-face {
  font-family: 'Gothic A1';
  font-style: normal;
  font-display: swap;
  font-weight: 900;
  src:
    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.woff2)
      format('woff2'),
    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.woff)
      format('woff'),
    url(https://cdn.jsdelivr.net/fontsource/fonts/gothic-a1@latest/korean-900-normal.ttf)
      format('truetype');
}
```
- 명시적으로 폰트 불러오기 
- 해당 경로는 자동으로 한국어 서브셋 처리 된 웹폰트임

## 💬 리뷰 요구사항
> #### 현업에선 어떤 방식으로 웹폰트 최적화를 진행할까요?
1. 폰트 직접 저장해서 , 사용하기 ?
2. 라이브러리 이용하기?
